### PR TITLE
Exclude META-INF files from shaded jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -331,6 +331,11 @@
                                         <exclude>META-INF/maven/**</exclude>
                                         <exclude>META-INF/*.xml</exclude>
                                         <exclude>LICENSE</exclude>
+                                        <exclude>META-INF/LICENSE</exclude>
+                                        <exclude>META-INF/LICENSE.txt</exclude>
+                                        <exclude>META-INF/license/*</exclude>
+                                        <exclude>META-INF/NOTICE</exclude>
+                                        <exclude>META-INF/NOTICE.txt</exclude>
                                         <exclude>META-INF/services/org.apache.commons.logging.LogFactory</exclude>
                                         <exclude>META-INF/DEPENDENCIES</exclude>
                                     </excludes>


### PR DESCRIPTION
Remove various unneeded META-INF based files from shaded jars.
Having them in target shaded jar resulted in multiple files
differing in case which made it impossible to extract jar to
case insensitive file system.